### PR TITLE
Invites

### DIFF
--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class InvitationsController < ApplicationController
       def create
-        invitation = Invitation.new(email: params[:email])
+        invitation = Invitation.new(invitation_params)
         authorize! :create, invitation
         invitation.sender = current_user
 
@@ -11,6 +11,13 @@ module Api
         else
           render json: invitation.errors, status: :unprocessable_entity
         end
+      end
+
+      private
+
+      def invitation_params
+        # No need to check privilege because only organizers can invite users
+        params.require(:invitation).permit(:email, :privilege)
       end
     end
   end

--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class InvitationsController < ApplicationController
+      def create
+        invitation = Invitation.new(email: params[:email])
+        authorize! :create, invitation
+        invitation.sender = current_user
+
+        if invitation.save
+          render :create, locals: { invitation: invitation }, status: :created
+        else
+          render json: invitation.errors, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -63,7 +63,7 @@ module Api
       end
 
       def user_params
-        p = params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :privilege, precincts: [])
+        p = params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :privilege, :invitation_token, precincts: [])
         p.delete(:privilege) unless current_user.organizer?
         p
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,9 +1,9 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "help@berniesanders.com"
+  default from: 'help@berniesanders.com'
 
   def invite(invitation_id)
     @invitation = Invitation.find invitation_id
     mail to: @invitation.email,
-         subject: "Invitation to Caucus Central"
+         subject: 'Invitation to Caucus Central'
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,9 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: "help@berniesanders.com"
+
+  def invite(invitation_id)
+    @invitation = Invitation.find invitation_id
+    mail to: @invitation.email,
+         subject: "Invitation to Caucus Central"
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -8,6 +8,8 @@ class Invitation < ActiveRecord::Base
 
   after_create :send_invite
 
+  enum privilege: [:unassigned, :captain, :organizer]
+
   private
 
   def recipient_not_registered

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,7 +3,7 @@ class Invitation < ActiveRecord::Base
 
   validates :email, presence: true, format: /\A[^@]+@[^@]+\z/, allow_blank: false
   validate :recipient_not_registered
-  
+
   before_create :generate_token!
 
   after_create :send_invite
@@ -13,7 +13,7 @@ class Invitation < ActiveRecord::Base
   private
 
   def recipient_not_registered
-    self.errors[:email] << 'has already been invited' if User.exists?(email: email)
+    errors[:email] << 'has already been invited' if User.exists?(email: email)
   end
 
   def generate_token!

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,28 @@
+class Invitation < ActiveRecord::Base
+  belongs_to :sender, class_name: 'User'
+
+  validates :email, presence: true, format: /\A[^@]+@[^@]+\z/, allow_blank: false
+  validate :recipient_not_registered
+  
+  before_create :generate_token!
+
+  after_create :send_invite
+
+  private
+
+  def recipient_not_registered
+    self.errors[:email] << 'has already been invited' if User.exists?(email: email)
+  end
+
+  def generate_token!
+    return unless token.blank?
+    loop do
+      self.token = SecureRandom.hex(32)
+      break token unless Invitation.exists?(token: token)
+    end
+  end
+
+  def send_invite
+    ApplicationMailer.invite(id).deliver_now
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,5 +18,6 @@ class User < ActiveRecord::Base
 
   def invitation_token=(token)
     self.invitation = Invitation.find_by_token(token)
+    self.privilege = invitation.privilege if invitation
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,20 @@ class User < ActiveRecord::Base
 
   has_and_belongs_to_many :precincts
   has_many :tokens, dependent: :destroy
+  belongs_to :invitation
 
   default_scope -> { order(last_name: :asc) }
 
   validates :email, :first_name, :last_name, presence: true, allow_blank: false
+  validates :invitation, presence: true, uniqueness: { message: 'has already been redeemed' }, unless: :organizer?
 
   enum privilege: [:unassigned, :captain, :organizer]
+
+  def invitation_token
+    invitation.token if invitation
+  end
+
+  def invitation_token=(token)
+    self.invitation = Invitation.find_by_token(token)
+  end
 end

--- a/app/views/api/v1/invitations/create.json.jbuilder
+++ b/app/views/api/v1/invitations/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.invitation do
   json.email invitation.email
-  json.token invitation.token
+  json.privilege invitation.privilege
 end

--- a/app/views/api/v1/invitations/create.json.jbuilder
+++ b/app/views/api/v1/invitations/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.invitation do
+  json.email invitation.email
+  json.token invitation.token
+end

--- a/app/views/application_mailer/invite.html.erb
+++ b/app/views/application_mailer/invite.html.erb
@@ -1,0 +1,7 @@
+<p>Hi there!</p>
+
+<p>You've been invited to join Caucus Central. Please complete your registration here:</p>
+
+</p><%= link_to new_api_v1_user_url(invitation_token: @invitation.token), new_api_v1_user_url(invitation_token: @invitation.token) %></p>
+
+<p>Thanks!</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
           patch :profile, to: 'users#update_profile'
         end
       end
+      resources :invitations, only: [:create]
     end
   end
 end

--- a/db/migrate/20160106012247_create_invitations.rb
+++ b/db/migrate/20160106012247_create_invitations.rb
@@ -1,0 +1,11 @@
+class CreateInvitations < ActiveRecord::Migration
+  def change
+    create_table :invitations do |t|
+      t.integer :sender_id
+      t.string :email
+      t.string :token
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160106020547_add_invitation_id_to_user.rb
+++ b/db/migrate/20160106020547_add_invitation_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddInvitationIdToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :invitation_id, :integer
+  end
+end

--- a/db/migrate/20160106030228_add_privilege_to_invitations.rb
+++ b/db/migrate/20160106030228_add_privilege_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddPrivilegeToInvitations < ActiveRecord::Migration
+  def change
+    add_column :invitations, :privilege, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160106020547) do
+ActiveRecord::Schema.define(version: 20160106030228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20160106020547) do
     t.string   "token"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "privilege"
   end
 
   create_table "precincts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160105204305) do
+ActiveRecord::Schema.define(version: 20160106020547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "precincts", id: :bigserial, force: :cascade do |t|
+  create_table "invitations", id: :bigserial, force: :cascade do |t|
+    t.integer  "sender_id"
+    t.string   "email"
+    t.string   "token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "precincts", force: :cascade do |t|
     t.string   "name"
     t.string   "county"
     t.integer  "supporting_attendees"
@@ -43,6 +51,7 @@ ActiveRecord::Schema.define(version: 20160105204305) do
     t.string  "email"
     t.string  "password_digest"
     t.integer "privilege"
+    t.integer "invitation_id"
   end
 
 end

--- a/spec/controllers/api/v1/invites_controller_spec.rb
+++ b/spec/controllers/api/v1/invites_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::InvitationsController do
   end
 
   describe '#create' do
-    let(:params) { { email: 'bernie@berniesanders.com' } }
+    let(:params) { { invitation: { email: 'bernie@berniesanders.com', privilege: 'captain' } } }
 
     subject { post :create, params }
 
@@ -23,14 +23,15 @@ describe Api::V1::InvitationsController do
         it 'returns the invitation' do
           expect(subject.body).to include_json(
             invitation: {
-              email: 'bernie@berniesanders.com'
+              email: 'bernie@berniesanders.com',
+              privilege: 'captain'
             }
           )
         end
       end
 
       context 'with invalid params' do
-        let(:params) { { email: 'not.an.email' } }
+        let(:params) { { invitation: { email: 'not.an.email' } } }
 
         it 'returns unprocessable' do
           expect(subject).to have_http_status(422)

--- a/spec/controllers/api/v1/invites_controller_spec.rb
+++ b/spec/controllers/api/v1/invites_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe Api::V1::InvitationsController do
+  shared_examples 'returns unauthorized' do
+    it 'returns 403' do
+      expect(subject).to have_http_status(403)
+    end
+  end
+
+  describe '#create' do
+    let(:params) { { email: 'bernie@berniesanders.com' } }
+
+    subject { post :create, params }
+
+    context 'user is organizer' do
+      before { login Fabricate(:organizer) }
+
+      context 'with valid params' do
+        it 'creates the invitation' do
+          expect(subject).to have_http_status(201)
+        end
+
+        it 'returns the invitation' do
+          expect(subject.body).to include_json(
+            invitation: {
+              email: 'bernie@berniesanders.com'
+            }
+          )
+        end
+      end
+
+      context 'with invalid params' do
+        let(:params) { { email: 'not.an.email' } }
+
+        it 'returns unprocessable' do
+          expect(subject).to have_http_status(422)
+        end
+      end
+    end
+
+    context 'user is captain' do
+      before { login Fabricate(:captain) }
+
+      it 'returns unauthorized' do
+        expect(subject).to have_http_status(403)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -106,7 +106,8 @@ describe Api::V1::UsersController do
   end
 
   describe '#create' do
-    let(:params) { { first_name: 'Bernie', last_name: 'Sanders', email: 'bernie@berniesanders.com', password: 'password', password_confirmation: 'password', privilege: 'captain' } }
+    let!(:invitation) { Fabricate(:invitation) }
+    let(:params) { { first_name: 'Bernie', last_name: 'Sanders', email: 'bernie@berniesanders.com', password: 'password', password_confirmation: 'password', privilege: 'captain', invitation_token: invitation.token } }
 
     subject { post :create, user: params }
 
@@ -132,6 +133,14 @@ describe Api::V1::UsersController do
 
       context 'with invalid params' do
         let(:params) { { first_name: 'Bernie' } }
+
+        it 'returns unprocessable' do
+          expect(subject).to have_http_status(422)
+        end
+      end
+
+      context 'without an invitation token' do
+        let(:params) { { first_name: 'Bernie', last_name: 'Sanders', email: 'bernie@berniesanders.com', password: 'password', password_confirmation: 'password', privilege: 'captain' } }
 
         it 'returns unprocessable' do
           expect(subject).to have_http_status(422)

--- a/spec/fabricators/invitation_fabricator.rb
+++ b/spec/fabricators/invitation_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator(:invitation) do
+  email { sequence(:email) { |i| "robin#{i}@thebatcave.com" } }
+end

--- a/spec/fabricators/invitation_fabricator.rb
+++ b/spec/fabricators/invitation_fabricator.rb
@@ -1,3 +1,4 @@
 Fabricator(:invitation) do
   email { sequence(:email) { |i| "robin#{i}@thebatcave.com" } }
+  privilege :captain
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -5,6 +5,7 @@ Fabricator(:user) do
   password 'aquamansuxsomuch'
   password_confirmation 'aquamansuxsomuch'
   privilege :unassigned
+  invitation
 end
 
 Fabricator(:captain, from: :user) do
@@ -13,4 +14,5 @@ end
 
 Fabricator(:organizer, from: :user) do
   privilege :organizer
+  invitation nil
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe User do
+  context 'when creating a new captain' do
+    describe 'with an invitation token' do
+      let!(:invitation) { Fabricate(:invitation) }
+      subject(:user) { Fabricate(:captain, invitation_token: invitation.token, invitation: nil) }
+
+      it 'assigns the invitation by its token' do
+        expect(user.invitation).to eq invitation
+      end
+    end
+
+    context 'without an invitation token' do
+      subject(:user) { Fabricate.build(:captain, invitation_token: nil, invitation: nil) }
+
+      it 'should not save' do
+        subject.save
+        expect(subject.errors[:invitation].length).to be >= 1
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,11 +3,15 @@ require 'rails_helper'
 describe User do
   context 'when creating a new captain' do
     describe 'with an invitation token' do
-      let!(:invitation) { Fabricate(:invitation) }
+      let!(:invitation) { Fabricate(:invitation, privilege: :organizer) }
       subject(:user) { Fabricate(:captain, invitation_token: invitation.token, invitation: nil) }
 
       it 'assigns the invitation by its token' do
         expect(user.invitation).to eq invitation
+      end
+
+      it 'assigns the privilege of its invitation' do
+        expect(user.privilege).to eq invitation.privilege
       end
     end
 


### PR DESCRIPTION
Added a single new endpoint: `POST /invitations`, which takes in params like so:

```
invitation: {
  email: 'bernie@berniesanders.org',
  privilege: 'captain'
}
```

Which creates the invitation, and sends off an email to the user containing a unique link with their invitation token. Now, when a new user is created, the `invitation_token` parameter is REQUIRED for the user to be created. All new users must have invitations, identified by the `invitation_token` and `invitation_id` fields. Only organizers may be created without invitations, and in order to do that, we'll have to manually create the first organizer and have him/her invite everyone else.

NOTE: Since I don't have the proper URL for the real front end, I just kind of made one up which adds `?invitation_token=abc123` to the end. Obviously we'd want that to go to the proper URL on the front end, and the front end needs to know about it coming in so that it may pass the token back to the backend while creating the new user!